### PR TITLE
Resolve ChatViewController memory leaks

### DIFF
--- a/BoostAI/UI/ChatResponseView.swift
+++ b/BoostAI/UI/ChatResponseView.swift
@@ -77,7 +77,7 @@ open class ChatResponseView: UIView {
     public var dataSource: ChatResponseViewDataSource?
     
     /// Our parent view that contains all dialog responses
-    public var delegate: ChatResponseViewDelegate?
+    public weak var delegate: ChatResponseViewDelegate?
     
     /// Avatar image view
     public weak var avatarImageView: UIImageView!

--- a/BoostAI/UI/ChatViewController.swift
+++ b/BoostAI/UI/ChatViewController.swift
@@ -265,11 +265,11 @@ open class ChatViewController: UIViewController {
             }
         }
         
-        backend.addConfigObserver(self) { (config, error) in
+        backend.addConfigObserver(self) { [weak self] (config, error) in
             DispatchQueue.main.async {
                 if let config = config {
-                    self.updateStyle(config: config)
-                    self.setBackendProperties(config: config)
+                    self?.updateStyle(config: config)
+                    self?.setBackendProperties(config: config)
                 }
             }
         }

--- a/BoostAI/UI/ConversationFeedbackViewController.swift
+++ b/BoostAI/UI/ConversationFeedbackViewController.swift
@@ -22,7 +22,7 @@
 
 import UIKit
 
-public protocol ConversationFeedbackDelegate {
+public protocol ConversationFeedbackDelegate: AnyObject {
     /// Hide the feedback view without closing the conversation
     func hideFeedback()
     
@@ -36,7 +36,7 @@ open class ConversationFeedbackViewController: UIViewController {
     open var backend: ChatBackend!
     
     /// Menu delegate (normally the parent view controller)
-    open var delegate: ConversationFeedbackDelegate?
+    open weak var delegate: ConversationFeedbackDelegate?
     
     /// Custom ChatConfig for overriding colors etc.
     public var customConfig: ChatConfig?


### PR DESCRIPTION
We have begun integrating the SDK into our app, but we are not seeing the `ChatViewController` being deallocated upon dismiss.

Reproduced in the Example project:
![Screenshot 2023-10-03 at 15 03 11](https://github.com/BoostAI/mobile-sdk-ios/assets/3541366/aefcd522-15db-4fd4-9e10-51f55bf812f0)

Applying these changes is allowing the ViewController to deallocate.